### PR TITLE
Fix conda installs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Following the recommendations of https://keepachangelog.com/en/1.0.0/
 master
 ------
 
+v0.2.2
+------
+- fixed: tentatively, the superfluous "v" from the version string has been dropped from conda releases (`#25 <https://github.com/chrisroadmap/climateforcing/pull/25>`_)
 - added: surface pressure introduced into `utci` (`#24 <https://github.com/chrisroadmap/climateforcing/pull/24>`_)
 - changed: humidity saturation vapour pressure back to Alduchov and Eskridge (1996) (`#24 <https://github.com/chrisroadmap/climateforcing/pull/24>`_)
 

--- a/conda-build/meta.yaml
+++ b/conda-build/meta.yaml
@@ -1,6 +1,9 @@
+{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
+
 package:
   name: climateforcing
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ data.get('version') }}
+
 
 source:
   git_url: ../


### PR DESCRIPTION
cut the initial "v" from the version string. Hopefully this works.